### PR TITLE
Add new MARA DH Coinbase Tag

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1279,7 +1279,8 @@
       "1A32KFEX7JNPmU1PVjrtiXRrTQcesT3Nf1"
     ],
     "tags": [
-      "MARA Pool"
+      "MARA Pool",
+      "MARA Made in USA"
     ],
     "link": "https://marapool.com"
   },


### PR DESCRIPTION
MARA DH will be updating their coinbase tag on  October 10th. This is PR is in preparation for that.